### PR TITLE
fix pointers.go missing "closing curly brace"

### DIFF
--- a/_content/tour/moretypes/pointers.go
+++ b/_content/tour/moretypes/pointers.go
@@ -15,3 +15,4 @@ func main() {
 	p = &j         // 指向 j
 	*p = *p / 37   // 通过指针对 j 进行除法运算
 	fmt.Println(j) // 查看 j 的值
+}


### PR DESCRIPTION
Missing "closing curly brace" because translation typo